### PR TITLE
Fix login history on wtmpdb systems

### DIFF
--- a/identities/src/components/UserActivity.vue
+++ b/identities/src/components/UserActivity.vue
@@ -36,6 +36,13 @@ If not, see <https://www.gnu.org/licenses/>.
 						v-if="processing"
 						class="size-icon"
 					/>
+					<span
+						v-if="historySourcesReady && !failedLoginHistoryAvailable"
+						class="text-sm font-normal text-gray-500"
+						title="This system does not provide a compatible failed-login history command."
+					>
+						Failed-login records unavailable
+					</span>
 				</div>
 				<Datepicker
 					v-model="range"
@@ -165,14 +172,29 @@ import moment from 'moment';
 import { darkModeInjectionKey } from '../keys';
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 import Table from './Table.vue';
+import { commandProbe, formatDateForLast, parseWtmpdbOutput, selectHistorySources } from '../loginHistory.mjs';
 
-function formatDateForLast(date) {
-	const year = date.getFullYear().toString().padStart(4, '0');
-	const month = (date.getMonth() + 1).toString().padStart(2, '0');
-	const day = date.getDate().toString().padStart(2, '0');
-	const hour = date.getHours().toString().padStart(2, '0');
-	const minute = date.getMinutes().toString().padStart(2, '0');
-	return `${year}-${month}-${day} ${hour}:${minute}`;
+let historySourcesPromise = null;
+
+async function commandExists(command) {
+	try {
+		const probe = commandProbe(command);
+		await useSpawn(probe.command, probe.options).promise();
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function getHistorySources() {
+	if (historySourcesPromise === null) {
+		historySourcesPromise = Promise.all(
+			['wtmpdb', 'last', 'lastb'].map(async command => [command, await commandExists(command)]),
+		).then(results => selectHistorySources(new Set(
+			results.filter(([, exists]) => exists).map(([command]) => command),
+		)));
+	}
+	return historySourcesPromise;
 }
 
 function sessionTimeToSentence(sessionTime) {
@@ -252,6 +274,8 @@ export default {
 		const history = ref([]);
 		const historyReactive = reactive(history);
 		const processing = ref(0);
+		const historySourcesReady = ref(false);
+		const failedLoginHistoryAvailable = ref(true);
 		const darkMode = inject(darkModeInjectionKey);
 		const filters = reactive({
 			user: {
@@ -301,56 +325,74 @@ export default {
 
 				try {
 					let tmpHistory = [];
-					for (let arg of ['last', 'lastb']) {
-						tmpHistory.push(
-							...(await useSpawn([arg, ...opts], { superuser: 'try' }).promise()).stdout.split('\n')
-								.filter(line => !(/^\s*$/.test(line) || /^[wb]tmp begins/.test(line))) // remove empty lines and last line
+					const sources = await getHistorySources();
+					if (sources.length === 0)
+						throw new Error('No compatible login history command found');
+
+					failedLoginHistoryAvailable.value = sources.some(source => source.authResult === 'bad');
+					historySourcesReady.value = true;
+
+					for (const source of sources) {
+						let output;
+						try {
+							output = (await useSpawn([...source.command, ...opts], { superuser: 'try' }).promise()).stdout;
+						} catch (error) {
+							if (source.authResult === 'bad') {
+								failedLoginHistoryAvailable.value = false;
+								continue;
+							}
+							throw error;
+						}
+
+						const entries = source.format === 'wtmpdb-json'
+							? parseWtmpdbOutput(output)
+							: output.split('\n')
+								.filter(line => !(/^\s*$/.test(line) || /^[wb]tmp begins/.test(line)))
 								.map(line => {
-									const bad = arg === 'lastb';
 									const match = line.match(/^(\S+)\s+(\S+( \S+)*)\s+(\d{1,3}(.\d{1,3}){3})\s+(\S+)( - (\S+)\s+\(([^\)]+)\)|\s+(\S+( \S+)*))/)?.slice(1);
 									if (!match)
 										return null;
-									const [user, tty, _1, ip, _2, sessionStart, _3, sessionEnd, sessionTime, stillRunning, _4] = match;
-									try {
-										const obj = reactive({
-											user,
-											tty,
-											ip,
-											sessionStart: tryDate(sessionStart),
-											sessionEnd: null, // end time or "still logged in" (or something else?)
-											sessionTime: sessionTime ? sessionTimeToSentence(sessionTime) : "0 Minutes",
-											overrideEndText: null,
-											authResult: bad ? 'bad' : 'good',
-										});
-										if (stillRunning === "still logged in" || stillRunning === "still running") {
-											// live update time
-											setInterval(() => {
-												obj.sessionTime = timeSince(sessionStart);
-												obj.sessionEnd = new Date();
-											}, 60 * 1000);
-											obj.sessionTime = timeSince(sessionStart);
-											obj.overrideEndText = stillRunning.replace(/\b(\w)/g, w => w.toUpperCase());
-										}
-										const sessionTimeObj = sessionTimeToObj(sessionTime);
-										obj.sessionEnd = tryDate(sessionEnd)
-											?? ((!sessionTime)
-												? new Date()
-												: moment(obj.sessionStart)
-													.add(sessionTimeObj.days, "days")
-													.add(sessionTimeObj.hours, "hours")
-													.add(sessionTimeObj.minutes, "minutes")
-													.toDate()
-											);
-										filters.user.set.add(obj.user);
-										filters.ip.set.add(obj.ip);
-										filters.tty.set.add(obj.tty);
-										filters.authResult.set.add(obj.authResult);
-										return obj;
-									} catch (error) {
-										throw new Error(error.message + `, trigger: ${line}`);
-									}
-								}).filter(entry => entry !== null)
-						)
+									const [user, tty, _1, ip, _2, sessionStart, _3, sessionEnd, sessionTime, stillRunning] = match;
+									return { user, tty, ip, sessionStart, sessionEnd, sessionTime, stillRunning, authResult: source.authResult };
+								})
+								.filter(entry => entry !== null);
+
+						tmpHistory.push(...entries.map((entry) => {
+							const { user, tty, ip, sessionStart, sessionEnd, sessionTime, stillRunning, authResult } = entry;
+							const obj = reactive({
+								user,
+								tty,
+								ip,
+								sessionStart: tryDate(sessionStart),
+								sessionEnd: null,
+								sessionTime: sessionTime ? sessionTimeToSentence(sessionTime) : "0 Minutes",
+								overrideEndText: null,
+								authResult,
+							});
+							if (stillRunning === "still logged in" || stillRunning === "still running") {
+								setInterval(() => {
+									obj.sessionTime = timeSince(sessionStart);
+									obj.sessionEnd = new Date();
+								}, 60 * 1000);
+								obj.sessionTime = timeSince(sessionStart);
+								obj.overrideEndText = stillRunning.replace(/\b(\w)/g, w => w.toUpperCase());
+							}
+							const sessionTimeObj = sessionTimeToObj(sessionTime);
+							obj.sessionEnd = tryDate(sessionEnd)
+								?? ((!sessionTime)
+									? new Date()
+									: moment(obj.sessionStart)
+										.add(sessionTimeObj.days, "days")
+										.add(sessionTimeObj.hours, "hours")
+										.add(sessionTimeObj.minutes, "minutes")
+										.toDate()
+								);
+							filters.user.set.add(obj.user);
+							filters.ip.set.add(obj.ip);
+							filters.tty.set.add(obj.tty);
+							filters.authResult.set.add(obj.authResult);
+							return obj;
+						}));
 					}
 					history.value = tmpHistory.sort(sortCallback.value);
 				} catch (state) {
@@ -490,6 +532,8 @@ export default {
 			history,
 			historyReactive,
 			processing,
+			historySourcesReady,
+			failedLoginHistoryAvailable,
 			darkMode,
 			filters,
 			compareFuncs,

--- a/identities/src/loginHistory.mjs
+++ b/identities/src/loginHistory.mjs
@@ -1,0 +1,71 @@
+export function formatDateForLast(date) {
+	const year = date.getFullYear().toString().padStart(4, '0');
+	const month = (date.getMonth() + 1).toString().padStart(2, '0');
+	const day = date.getDate().toString().padStart(2, '0');
+	const hour = date.getHours().toString().padStart(2, '0');
+	const minute = date.getMinutes().toString().padStart(2, '0');
+	const second = date.getSeconds().toString().padStart(2, '0');
+	return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+}
+
+export function commandProbe(command) {
+	return {
+		command: ['sh', '-c', 'command -v "$1" >/dev/null 2>&1', 'sh', command],
+		options: { superuser: 'try' },
+	};
+}
+
+export function selectHistorySources(availableCommands) {
+	if (availableCommands.has('last') && availableCommands.has('lastb')) {
+		return [
+			{ command: ['last'], format: 'last-text', authResult: 'good' },
+			{ command: ['lastb'], format: 'last-text', authResult: 'bad' },
+		];
+	}
+
+	const sources = [];
+
+	if (availableCommands.has('wtmpdb')) {
+		sources.push({
+			command: ['wtmpdb', 'last', '--json'],
+			format: 'wtmpdb-json',
+			authResult: 'good',
+		});
+	} else if (availableCommands.has('last')) {
+		sources.push({
+			command: ['last'],
+			format: 'last-text',
+			authResult: 'good',
+		});
+	}
+
+	if (availableCommands.has('lastb')) {
+		sources.push({
+			command: ['lastb'],
+			format: 'last-text',
+			authResult: 'bad',
+		});
+	}
+
+	return sources;
+}
+
+export function parseWtmpdbOutput(output) {
+	const { entries = [] } = JSON.parse(output);
+
+	return entries.map((entry) => {
+		const logout = entry.logout?.trim() || null;
+		const logoutIsTimestamp = logout !== null && !isNaN(new Date(logout).getTime());
+
+		return {
+			user: entry.user,
+			tty: entry.tty ?? '',
+			ip: entry.hostname ?? '',
+			sessionStart: entry.login,
+			sessionEnd: logoutIsTimestamp ? logout : null,
+			sessionTime: entry.length ?? null,
+			stillRunning: logoutIsTimestamp ? null : logout,
+			authResult: 'good',
+		};
+	});
+}

--- a/identities/tests/loginHistory.test.mjs
+++ b/identities/tests/loginHistory.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import {
+	commandProbe,
+	formatDateForLast,
+	parseWtmpdbOutput,
+	selectHistorySources,
+} from '../src/loginHistory.mjs';
+
+test('prefers wtmpdb with a util-linux fallback for older Debian releases', async () => {
+	const manifest = JSON.parse(await readFile(new URL('../../manifest.json', import.meta.url)));
+
+	assert.ok(manifest.dependencies.debian_common.includes('wtmpdb | util-linux'));
+	assert.ok(!manifest.dependencies.debian_common.includes('util-linux'));
+});
+
+test('formats history range timestamps with seconds', () => {
+	const date = new Date(2026, 6, 11, 9, 8, 7);
+
+	assert.equal(formatDateForLast(date), '2026-07-11 09:08:07');
+});
+
+test('checks command availability without requiring administrative mode', () => {
+	assert.deepEqual(commandProbe('wtmpdb'), {
+		command: ['sh', '-c', 'command -v "$1" >/dev/null 2>&1', 'sh', 'wtmpdb'],
+		options: { superuser: 'try' },
+	});
+});
+
+test('preserves the complete legacy backend when last and lastb are available', () => {
+	assert.deepEqual(
+		selectHistorySources(new Set(['wtmpdb', 'last', 'lastb'])),
+		[
+			{ command: ['last'], format: 'last-text', authResult: 'good' },
+			{ command: ['lastb'], format: 'last-text', authResult: 'bad' },
+		],
+	);
+});
+
+test('uses successful wtmpdb history without requiring lastb', () => {
+	assert.deepEqual(
+		selectHistorySources(new Set(['wtmpdb', 'last'])),
+		[
+			{ command: ['wtmpdb', 'last', '--json'], format: 'wtmpdb-json', authResult: 'good' },
+		],
+	);
+});
+
+test('retains legacy last and lastb support', () => {
+	assert.deepEqual(
+		selectHistorySources(new Set(['last', 'lastb'])),
+		[
+			{ command: ['last'], format: 'last-text', authResult: 'good' },
+			{ command: ['lastb'], format: 'last-text', authResult: 'bad' },
+		],
+	);
+});
+
+test('parses wtmpdb JSON including entries without a tty', () => {
+	const output = JSON.stringify({
+		entries: [
+			{
+				user: 'admin',
+				tty: '',
+				hostname: '127.0.0.1',
+				login: '2026-07-11T10:25:12-0600',
+				logout: '2026-07-11T10:25:28-0600',
+				length: '00:00',
+			},
+			{
+				user: 'root',
+				tty: 'pts/0',
+				hostname: '192.0.2.10',
+				login: '2026-07-11T10:31:15-0600',
+				logout: 'still logged in ',
+			},
+		],
+	});
+
+	assert.deepEqual(parseWtmpdbOutput(output), [
+		{
+			user: 'admin',
+			tty: '',
+			ip: '127.0.0.1',
+			sessionStart: '2026-07-11T10:25:12-0600',
+			sessionEnd: '2026-07-11T10:25:28-0600',
+			sessionTime: '00:00',
+			stillRunning: null,
+			authResult: 'good',
+		},
+		{
+			user: 'root',
+			tty: 'pts/0',
+			ip: '192.0.2.10',
+			sessionStart: '2026-07-11T10:31:15-0600',
+			sessionEnd: null,
+			sessionTime: null,
+			stillRunning: 'still logged in',
+			authResult: 'good',
+		},
+	]);
+});

--- a/manifest.json
+++ b/manifest.json
@@ -64,7 +64,7 @@
             "samba",
             "samba-common-bin",
             "sudo",
-            "util-linux",
+            "wtmpdb | util-linux",
             "perl",
             "openssh-client"
         ]


### PR DESCRIPTION
Closes #9.

## Summary

- detect the available login-history backend instead of unconditionally running both `last` and `lastb`
- use `wtmpdb last --json` on systems that no longer provide the complete legacy command pair
- preserve legacy `last` + `lastb` behavior where both commands remain available
- include seconds in date-range arguments, as required by `wtmpdb`
- keep successful-login history available when failed-login history is unsupported, with a visible non-error notice
- prefer the Debian dependency `wtmpdb | util-linux`, so Trixie installs `wtmpdb` while Bookworm can retain `util-linux`

## Root cause

Ubuntu 24.10+ and Debian 13 replace the traditional `last` implementation with `wtmpdb` and do not provide `lastb`. The existing loop successfully queried `last`, then discarded the complete result when spawning `lastb` failed. Text parsing was also unreliable for `wtmpdb` entries whose TTY field is empty.

## Compatibility behavior

| Available commands | Selected backend |
| --- | --- |
| `last` and `lastb` | legacy text output from both commands |
| `wtmpdb` without `lastb` | successful sessions from `wtmpdb last --json`; failed-login records marked unavailable |
| legacy `last` only | successful sessions from `last`; failed-login records marked unavailable |

`wtmpdb` does not currently provide a supported equivalent for the traditional failed-login database, so the UI does not imply that failed-login history is empty.

## Verification

- Node regression suite: 7 tests passed
- Houston common library suite on Debian 13: 64 tests passed
- production build completed on Debian 13
- real Cockpit browser flow displayed `wtmpdb` sessions, including entries with an empty TTY, without an error notification
- legacy backend selection and Debian dependency fallback are covered by regression tests
- disposable user lifecycle passed: create account, set login password, set Samba password, verify private home, and delete account/files

## AI assistance disclosure

OpenAI Codex assisted with investigation, implementation, regression tests, and validation. The resulting diff and test evidence were reviewed before submission.
